### PR TITLE
Python 3.4 bugfix: avoid crashing

### DIFF
--- a/deb_pkg_tools/cache.py
+++ b/deb_pkg_tools/cache.py
@@ -286,7 +286,7 @@ class CachedPackage(sqlite3.Row):
 
         :returns: The pathname (a string).
         """
-        return str(self['pathname']).decode(self.cache.character_encoding)
+        return self['pathname'].decode(self.cache.character_encoding)
 
     @property
     def timestamp(self):


### PR DESCRIPTION
```
  File "/home/build/soft/soft-venv/lib/python3.4/site-packages/deb_pkg_tools/checks.py", line 93, in check_duplicate_files
    fields, contents = inspect_package(archive.filename, cache=cache)
  File "/home/build/soft/soft-venv/lib/python3.4/site-packages/deb_pkg_tools/package.py", line 312, in inspect_package
    return (inspect_package_fields(archive, cache),
  File "/home/build/soft/soft-venv/lib/python3.4/site-packages/deb_pkg_tools/package.py", line 350, in inspect_package_fields
    return cache[archive].control_fields
  File "/home/build/soft/soft-venv/lib/python3.4/site-packages/cached_property.py", line 49, in __get__
    value = self.func(obj)
  File "/home/build/soft/soft-venv/lib/python3.4/site-packages/deb_pkg_tools/cache.py", line 313, in control_fields
    control_fields = inspect_package_fields(self.pathname)
  File "/home/build/soft/soft-venv/lib/python3.4/site-packages/cached_property.py", line 49, in __get__
    value = self.func(obj)
  File "/home/build/soft/soft-venv/lib/python3.4/site-packages/deb_pkg_tools/cache.py", line 289, in pathname
    return str(self['pathname']).decode(self.cache.character_encoding)
AttributeError: 'str' object has no attribute 'decode'
```

I haven't tested this on python 2 yet, though.