### PR TITLE
Add support for ".udeb" micro packages

### DIFF
--- a/deb_pkg_tools/package.py
+++ b/deb_pkg_tools/package.py
@@ -188,7 +188,7 @@ def find_package_archives(directory):
     """
     archives = []
     for entry in os.listdir(directory):
-        if entry.endswith('.deb'):
+        if entry.endswith(('.deb', '.udeb')):
             pathname = os.path.join(directory, entry)
             if os.path.isfile(pathname):
                 archives.append(parse_filename(pathname))


### PR DESCRIPTION
These are less common and typically only used with a 
debian installer but still valid packages nonetheless. 
See https://wiki.debian.org/udeb

Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>