### PR TITLE
Ensure device nodes can be parsed from contents

### DIFF
--- a/deb_pkg_tools/package.py
+++ b/deb_pkg_tools/package.py
@@ -716,7 +716,13 @@ def inspect_package_contents(archive, cache=None):
         fields = line.split(None, 5)
         permissions = fields[0]
         owner, group = fields[1].split('/')
-        size = int(fields[2])
+
+        try:
+            size = int(fields[2])
+        except ValueError:
+            # Device nodes show device ID info instead of size - set to zero
+            size = 0
+
         modified = fields[3] + ' ' + fields[4]
         pathname = re.sub('^./', '/', fields[5])
         pathname, _, target = pathname.partition(' -> ')


### PR DESCRIPTION
Hey @xolox !

Came across an issue parsing the contents of a package using `deb_pkg_tools` today. Packages which reference device nodes (granted odd and obscure but do exist), populate the size field of these nodes as their block device IDs in `ls` and `dpkg-deb -c`:

```bash
$ dpkg-deb -c libxenomai1_2.6.4-1_1jessie_1da_i386.deb
crw-r--r-- root/root     150,0 2015-12-07 16:40 ./dev/rtp0
crw-r--r-- root/root     150,1 2015-12-07 16:40 ./dev/rtp1
crw-r--r-- root/root     150,2 2015-12-07 16:40 ./dev/rtp2
crw-r--r-- root/root     150,3 2015-12-07 16:40 ./dev/rtp3
crw-r--r-- root/root     150,4 2015-12-07 16:40 ./dev/rtp4                                 
```

This causes a `ValueError` when attempting to coerce the parsed size value as an integer within the `inspect_package_contents` function:

```python
>>> p.inspect_package_contents("libxenomai1_2.6.4-1_1jessie_1da_i386.deb")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/tgibson/cloudsmith/.venv/lib/python3.8/site-packages/deb_pkg_tools/package.py", line 719, in inspect_package_contents
    size = int(fields[2])
ValueError: invalid literal for int() with base 10: '150,0'
```

Change below simply wraps the assignment and cast in a try/catch and ensures the size is reported zero. It's not *quite* correct that its zero sized, but it does allow for the cast, and ensures the types remain the same within the `ArchiveEntry` tuple for other users.

Let me know if you need anything else here.

Thanks!
Tom